### PR TITLE
Fix typo in RxStateExample #trivial 

### DIFF
--- a/RxStateExample/RxStateExample/StateManagment/ErrorStateManagement.swift
+++ b/RxStateExample/RxStateExample/StateManagment/ErrorStateManagement.swift
@@ -33,7 +33,7 @@ extension Store {
     }
     
     static func reduce(state: Store.ErrorState, action: Store.ErrorAction) -> Store.ErrorState {
-        switch sction {
+        switch action {
         case let .addPresentError(error):
             var state = state
             state.presentableError = error

--- a/RxStateExample/RxStateExample/StateManagment/ErrorStateManagement.swift
+++ b/RxStateExample/RxStateExample/StateManagment/ErrorStateManagement.swift
@@ -32,7 +32,7 @@ extension Store {
         case addSilentError(silentError: Error)
     }
     
-    static func reduce(state: Store.ErrorState, sction: Store.ErrorAction) -> Store.ErrorState {
+    static func reduce(state: Store.ErrorState, action: Store.ErrorAction) -> Store.ErrorState {
         switch sction {
         case let .addPresentError(error):
             var state = state


### PR DESCRIPTION
Description:

I found a typo in the RxState/RxStateExample/RxStateExample/StateManagment and fixed it. 

Changes Made:

I made the following changes:

1. Change File Name
- ErrorStateManagment -> ErrorStateManagement

2. Change 'func reduce()' Parameter Name
- sction -> action

Thanks you 🙏